### PR TITLE
Small fix to _buildServerConfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,9 @@ Now create a directory **in the parent directory of your angular project** that 
 <body>
   <script src="https://unpkg.com/zone.js"></script>
   <script src="https://unpkg.com/single-spa/lib/umd/single-spa.js"></script>
-  <script src="/name-of-angular-project/dist/name-of-angular-project/main.js"></script>
+  <script src="/nameOfAngularProject/dist/nameOfAngularProject/main.js"></script>
   <script>
-    singleSpa.registerApplication('test3', window.test3.default, location => true);
+    singleSpa.registerApplication('nameOfAngularProject', window.nameOfAngularProject.default, location => true);
     singleSpa.start();
   </script>
 </body>

--- a/src/builders/dev-server/index.ts
+++ b/src/builders/dev-server/index.ts
@@ -23,18 +23,23 @@ export class SingleSpaDevServer extends DevServerBuilder {
         const browserBuilder = new SingleSpaBrowserBuilder(this.context);
         const webpackConfig = browserBuilder.buildWebpackConfig(root, projectRoot, host, options);
         this.context.logger.info(tags.oneLine `
-        SINGLE-SPA-ANGULAR: Angular dev server is serving application as a single module`);
+        [single-spa-angular]: Angular dev server is serving application as a single module`);
         return webpackConfig;
     }    
     _buildServerConfig(root, projectRoot, options, browserOptions) {
         // @ts-ignore
         const devServerConfig = super._buildServerConfig(root, projectRoot, options, browserOptions);
+        const contentBase = path.resolve(root, projectRoot.serveDirectory || '../');
+        const lastPos = root.lastIndexOf('/') || root.lastIndexOf(path.sep);
+        const publicPath = root.slice(lastPos) + '/' + options.outputPath        
+        this.context.logger.info(tags.oneLine `[single-spa-angular]: webpack output is served from ${publicPath}`);
+        this.context.logger.info(tags.oneLine `[single-spa-angular]: content not from webpack is served from ${contentBase}`);
 
         return webpackMerge.smart(devServerConfig, {
             // @ts-ignore
-            contentBase: path.resolve(root, projectRoot.serveDirectory || '../'),
+            contentBase: contentBase,
             historyApiFallback: true,
-            publicPath: root.slice(root.lastIndexOf(path.sep)) + '/' + options.outputPath,
+            publicPath: publicPath,
         })
     }
 }


### PR DESCRIPTION
Small issue with the public path as it stands, in my environment the slice & concatenate was failing because `path.sep` was `\` and my root used `/`. 

In resolving the issue I also tidied up the console output and added a little extra.