### PR TITLE
Fixing --project option in builder

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "single-spa-angular",
-  "version": "3.0.0-beta.16",
+  "version": "3.0.0-beta.17",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/builders/single-spa-webpack-builder.ts
+++ b/src/builders/single-spa-webpack-builder.ts
@@ -4,7 +4,7 @@ import { BuilderContext } from '@angular-devkit/architect';
 import * as webpackMerge from 'webpack-merge';
 
 export function buildWebpackConfig(root: Path, config: string, baseWebpackConfig: Configuration, options: any, context: BuilderContext): Configuration {
-  const libraryName = options.libraryName || context.workspace.getDefaultProjectName() || context.targetSpecifier && context.targetSpecifier.project;
+  const libraryName = options.libraryName || context.targetSpecifier && context.targetSpecifier.project || context.workspace.getDefaultProjectName();
 
   const singleSpaConfig = {
     output: {


### PR DESCRIPTION
If defaultProject is set in angular.json it will take precedence over the --project option.
Mentioned this in #66 .