### PR TITLE
Added props to bootstrapFunction

### DIFF
--- a/src/browser-lib/single-spa-angular.ts
+++ b/src/browser-lib/single-spa-angular.ts
@@ -68,7 +68,7 @@ function mount(opts, props) {
       containerEl.innerHTML = opts.template;
     })
     .then(() => {
-      const bootstrapPromise = opts.bootstrapFunction()
+      const bootstrapPromise = opts.bootstrapFunction(props)
       if (!(bootstrapPromise instanceof Promise)) {
         throw Error(`single-spa-angular: the opts.bootstrapFunction must return a promise, but instead returned a '${typeof bootstrapPromise}' that is not a Promise`);
       }


### PR DESCRIPTION
Hi, this change makes possible to use the customProps from the register application into the singleSpaAngular bootstrapFunction. for example: 

```javascript
bootstrapFunction: (props) => platformBrowserDynamic(
    {provide: 'environment', useValue: props.environment }
]).bootstrapModule(AppModule)
```