### PR TITLE
fix: support Angular CLI 21.2.x findUpSync rename

### DIFF
--- a/libs/single-spa-community-angular/webpack/index.ts
+++ b/libs/single-spa-community-angular/webpack/index.ts
@@ -1,5 +1,10 @@
 import * as fs from 'fs';
-import { findUp } from '@angular/cli/src/utilities/find-up';
+
+// Angular CLI 21.2+ renamed the sync variant to `findUpSync`; ≤21.1 only exports `findUp` (sync).
+// We load both at runtime and prefer `findUpSync` so the code works across both ranges.
+// eslint-disable-next-line  @typescript-eslint/no-var-requires
+const { findUpSync: _findUpSync, findUp: _findUp } = require('@angular/cli/src/utilities/find-up');
+const findUp: (names: string | string[], from: string) => string | null = _findUpSync ?? _findUp;
 
 import { externals } from './externals';
 import { removeMiniCssExtractRules } from './webpack-5/remove-mini-css-extract';


### PR DESCRIPTION
In Angular CLI 21.2, the synchronous findUp utility was renamed to findUpSync, making the old findUp async. Importing findUp statically then passing its return value (now a Promise) as a file path caused:
```
  "The "path" argument must be of type string or an instance of Buffer
  or URL. Received an instance of Promise."
```
Replace the static import with a runtime require that prefers findUpSync (21.2+) and falls back to findUp (≤21.1), keeping compatibility across both CLI ranges without breaking existing behaviour.