### PR TITLE
docs: remove outdated Project Status section from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,12 +14,6 @@ This lets you have multiple Angular microfrontends coexist within the same page.
 
 See [documentation on single-spa.js.org](https://single-spa.js.org/docs/ecosystem-angular.html).
 
-## Project Status
-
-The package has been republished under the `@single-spa-community` scope due to a change in maintainership.
-
-> **Note:** This package is the continuation of the original `single-spa-angular` package. If you are migrating from `single-spa-angular`, simply update the package name in your dependencies — no other changes are required.
-
 ## Compatibility
 
 | `single-spa-angular` | Angular |


### PR DESCRIPTION
The package was renamed back to single-spa-angular in #572, but the README still described the interim @single-spa-community scope and migration note.

## PR Type

What kind of change does this PR introduce?

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Docs update
```